### PR TITLE
Pinned install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     ],
     packages=["objexplore"],
     include_package_data=True,
-    install_requires=["blessed", "rich"],
+    install_requires=["blessed==1.17.12", "rich==10.9.0"],
 )


### PR DESCRIPTION
Fixes issue #3 by pinning dependencies in setup.py.  Also, note that your requirements.txt doesn't include flake8 so `make check` fails until flake8 is installed.  I did not fix this as wasn't sure which version you're using.  

```
[I] ➜ make check
mypy objexplore
Success: no issues found in 8 source files
flake8 .
(objexplore)
objexplore on fix_dependencies [!?] via objexplore via 🐍 objexplore took 2s
[I] ➜ make format
black .
All done! ✨ 🍰 ✨
9 files left unchanged.
```