### PR TITLE
Update rich version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     ],
     packages=["objexplore"],
     include_package_data=True,
-    install_requires=["blessed==1.17.12", "rich==10.9.0"],
+    install_requires=["blessed==1.17.12", "rich==11.2.0"],
 )


### PR DESCRIPTION
Looks from the `requirements.txt` file that the expected rich version is `11.2.0`, but pip install currently requires `10.9.0`.

Brilliant utility, thanks!